### PR TITLE
Dependency Mosaico: use build branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: reflexive-communications/uk.co.vedaconsulting.mosaico
           path: uk.co.vedaconsulting.mosaico
-          ref: build-2-8
+          ref: build
 
       - name: Self checkout
         uses: actions/checkout@v3

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2022-04-10</releaseDate>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>


### PR DESCRIPTION
The forked extension's `build` branch contains a fully working Mosaico extension. (and it will always have the most latest)