### PR TITLE
Format code

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 tabWidth: 4
-printWidth: 100
+printWidth: 120
 trailingComma: 'all'
 singleQuote: true
 bracketSpacing: false

--- a/CRM/RcMosaicoTemplate/TemplateConfig.php
+++ b/CRM/RcMosaicoTemplate/TemplateConfig.php
@@ -3,12 +3,17 @@
 /*
  * class CRM_RcMosaicoTemplate_TemplateConfig
  */
+
 class CRM_RcMosaicoTemplate_TemplateConfig
 {
     const TEMPLATE_NAME = 'rc-base';
+
     const TEMPLATE_TITLE = 'RC Base Template';
+
     const TEMPLATE_PATH = 'assets/rc-base-template.html';
+
     const TEMPLATE_THUMBNAIL = 'assets/edres/_full.png';
+
     /*
      * It returns the config of our template.
      * @return array

--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-mosaico-template/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2022-11-06</releaseDate>
-    <version>1.0.4</version>
+    <releaseDate>2023-03-08</releaseDate>
+    <version>1.0.5</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/rc_mosaico_template.civix.php
+++ b/rc_mosaico_template.civix.php
@@ -9,12 +9,13 @@
 class CRM_RcMosaicoTemplate_ExtensionUtil
 {
     const SHORT_NAME = 'rc_mosaico_template';
+
     const LONG_NAME = 'rc-mosaico-template';
+
     const CLASS_PREFIX = 'CRM_RcMosaicoTemplate';
 
     /**
      * Translate a string using the extension's domain.
-     *
      * If the extension doesn't have a specific translation
      * for the string, fallback to the default translations.
      *
@@ -31,6 +32,7 @@ class CRM_RcMosaicoTemplate_ExtensionUtil
         if (!array_key_exists('domain', $params)) {
             $params['domain'] = [self::LONG_NAME, null];
         }
+
         return ts($text, $params);
     }
 
@@ -50,6 +52,7 @@ class CRM_RcMosaicoTemplate_ExtensionUtil
         if ($file === null) {
             return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
         }
+
         return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
 
@@ -210,7 +213,6 @@ function _rc_mosaico_template_civix_civicrm_disable()
  * @return mixed
  *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *   for 'enqueue', returns void
- *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _rc_mosaico_template_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
@@ -234,7 +236,6 @@ function _rc_mosaico_template_civix_upgrader()
 
 /**
  * Search directory tree for files which match a glob pattern.
- *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
  * for backward compatibility of extension code that uses it.
@@ -251,7 +252,6 @@ function _rc_mosaico_template_civix_find_files($dir, $pattern)
 
 /**
  * (Delegated) Implements hook_civicrm_managed().
- *
  * Find any *.mgd.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
@@ -276,9 +276,7 @@ function _rc_mosaico_template_civix_civicrm_managed(&$entities)
 
 /**
  * (Delegated) Implements hook_civicrm_caseTypes().
- *
  * Find any and return any files matching "xml/case/*.xml"
- *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
@@ -305,9 +303,7 @@ function _rc_mosaico_template_civix_civicrm_caseTypes(&$caseTypes)
 
 /**
  * (Delegated) Implements hook_civicrm_angularModules().
- *
  * Find any and return any files matching "ang/*.ang.php"
- *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
@@ -331,7 +327,6 @@ function _rc_mosaico_template_civix_civicrm_angularModules(&$angularModules)
 
 /**
  * (Delegated) Implements hook_civicrm_themes().
- *
  * Find any and return any files matching "*.theme.php"
  */
 function _rc_mosaico_template_civix_civicrm_themes(&$themes)
@@ -351,7 +346,6 @@ function _rc_mosaico_template_civix_civicrm_themes(&$themes)
 
 /**
  * Glob wrapper which is guaranteed to return an array.
- *
  * The documentation for glob() says, "On some systems it is impossible to
  * distinguish between empty match and an error." Anecdotally, the return
  * result for an empty match is sometimes array() and sometimes FALSE.
@@ -366,6 +360,7 @@ function _rc_mosaico_template_civix_civicrm_themes(&$themes)
 function _rc_mosaico_template_civix_glob($pattern)
 {
     $result = glob($pattern);
+
     return is_array($result) ? $result : [];
 }
 
@@ -390,6 +385,7 @@ function _rc_mosaico_template_civix_insert_navigation_menu(&$menu, $path, $item)
                 'active' => 1,
             ], $item),
         ];
+
         return true;
     } else {
         // Find an recurse into the next level down
@@ -404,6 +400,7 @@ function _rc_mosaico_template_civix_insert_navigation_menu(&$menu, $path, $item)
                 $found = _rc_mosaico_template_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
             }
         }
+
         return $found;
     }
 }
@@ -469,7 +466,6 @@ function _rc_mosaico_template_civix_civicrm_alterSettingsFolders(&$metaDataFolde
 
 /**
  * (Delegated) Implements hook_civicrm_entityTypes().
- *
  * Find any *.entityType.php files, merge their content, and return.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes

--- a/rc_mosaico_template.php
+++ b/rc_mosaico_template.php
@@ -89,7 +89,6 @@ function rc_mosaico_template_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
 
 /**
  * Implements hook_civicrm_managed().
- *
  * Generate a list of entities to create/deactivate/delete when this module
  * is installed, disabled, uninstalled.
  *
@@ -102,7 +101,6 @@ function rc_mosaico_template_civicrm_managed(&$entities)
 
 /**
  * Implements hook_civicrm_caseTypes().
- *
  * Add CiviCase types provided by this extension.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
@@ -114,7 +112,6 @@ function rc_mosaico_template_civicrm_caseTypes(&$caseTypes)
 
 /**
  * Implements hook_civicrm_angularModules().
- *
  * Add Angular modules provided by this extension.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
@@ -137,7 +134,6 @@ function rc_mosaico_template_civicrm_alterSettingsFolders(&$metaDataFolders = nu
 
 /**
  * Implements hook_civicrm_entityTypes().
- *
  * Declare entity types provided by this module.
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
@@ -175,5 +171,5 @@ function rc_mosaico_template_civicrm_mosaicoBaseTemplates(&$templates)
  */
 function rc_mosaico_template_civicrm_mosaicoConfig(&$config)
 {
-    $config['tinymceConfig']['forced_root_block'] ='div';
+    $config['tinymceConfig']['forced_root_block'] = 'div';
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -20,6 +20,7 @@ $loader->register();
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
+ *
  * @return string
  *   Response output (if the command executed normally).
  * @throws \RuntimeException
@@ -27,8 +28,8 @@ $loader->register();
  */
 function cv($cmd, $decode = 'json')
 {
-    $cmd = 'cv ' . $cmd;
-    $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+    $cmd = 'cv '.$cmd;
+    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
     putenv("CV_OUTPUT=json");
 
@@ -53,6 +54,7 @@ function cv($cmd, $decode = 'json')
             if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
                 throw new \RuntimeException("Command failed ($cmd):\n$result");
             }
+
             return $result;
 
         case 'json':


### PR DESCRIPTION
- Reformat PHP to PSR-12
- Reformat JS
- readme: use hyphens for `cv en some-extension`
- remove `,` after last element of inline arrays
