### PR TITLE
Standardize tests

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -22,8 +22,8 @@
         <url desc="Support">https://github.com/reflexive-communications/rc-mosaico-template/issues</url>
         <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2023-03-09</releaseDate>
-    <version>1.1.0</version>
+    <releaseDate>2023-03-16</releaseDate>
+    <version>1.2.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/tests/phpunit/CRM/RcMosaicoTemplate/ConfigTest.php
+++ b/tests/phpunit/CRM/RcMosaicoTemplate/ConfigTest.php
@@ -13,14 +13,14 @@ class CRM_RcMosaicoTemplate_ConfigTest extends HeadlessTestCase
     public function testTemplates()
     {
         $template = CRM_RcMosaicoTemplate_TemplateConfig::getTemplate();
-        self::assertArrayHasKey("name", $template, "The config has to contain the name key.");
-        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_NAME, $template["name"], "The name has to be the expected value.");
-        self::assertArrayHasKey("title", $template, "The config has to contain the title key.");
-        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_TITLE, $template["title"], "The title has to be the expected value.");
-        self::assertArrayHasKey("path", $template, "The config has to contain the path key.");
-        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_PATH, $template["path"], "The path has to be the expected value.");
-        self::assertArrayHasKey("thumbnail", $template, "The config has to contain the thumbnail key.");
-        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_THUMBNAIL, $template["thumbnail"], "The thumbnail has to be the expected value.");
-        self::assertCount(4, $template, "The template has to contain only the name, title, path, thumbnail items.");
+        self::assertArrayHasKey('name', $template, 'The config has to contain the name key.');
+        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_NAME, $template['name'], 'The name has to be the expected value.');
+        self::assertArrayHasKey('title', $template, 'The config has to contain the title key.');
+        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_TITLE, $template['title'], 'The title has to be the expected value.');
+        self::assertArrayHasKey('path', $template, 'The config has to contain the path key.');
+        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_PATH, $template['path'], 'The path has to be the expected value.');
+        self::assertArrayHasKey('thumbnail', $template, 'The config has to contain the thumbnail key.');
+        self::assertEquals(CRM_RcMosaicoTemplate_TemplateConfig::TEMPLATE_THUMBNAIL, $template['thumbnail'], 'The thumbnail has to be the expected value.');
+        self::assertCount(4, $template, 'The template has to contain only the name, title, path, thumbnail items.');
     }
 }

--- a/tests/phpunit/CRM/RcMosaicoTemplate/ConfigTest.php
+++ b/tests/phpunit/CRM/RcMosaicoTemplate/ConfigTest.php
@@ -1,27 +1,12 @@
 <?php
 
+use Civi\RcMosaicoTemplate\HeadlessTestCase;
+
 /**
- * This is a generic test class for the extension (implemented with PHPUnit).
+ * @group headless
  */
-class CRM_RcMosaicoTemplate_ConfigTest extends \PHPUnit\Framework\TestCase
+class CRM_RcMosaicoTemplate_ConfigTest extends HeadlessTestCase
 {
-    /**
-     * The setup() method is executed before the test is executed (optional).
-     */
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    /**
-     * The tearDown() method is executed after the test was executed (optional)
-     * This can be used for cleanup.
-     */
-    public function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     /**
      * Check the templates after the hook function.
      */

--- a/tests/phpunit/Civi/RcMosaicoTemplate/HeadlessTestCase.php
+++ b/tests/phpunit/Civi/RcMosaicoTemplate/HeadlessTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Civi\RcMosaicoTemplate;
+
+use Civi\Test;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group headless
+ */
+class HeadlessTestCase extends TestCase implements HeadlessInterface
+{
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws \CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB
+        Test::headless()
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+
+    /**
+     * @return void
+     */
+    public function setUpHeadless(): void
+    {
+    }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,12 +1,14 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
+
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
-$loader = new \Composer\Autoload\ClassLoader();
+$loader = new ClassLoader();
 $loader->add('CRM_', __DIR__);
 $loader->add('Civi\\', __DIR__);
 $loader->add('api_', __DIR__);
@@ -29,9 +31,9 @@ $loader->register();
 function cv($cmd, $decode = 'json')
 {
     $cmd = 'cv '.$cmd;
-    $descriptorSpec = [0 => ["pipe", "r"], 1 => ["pipe", "w"], 2 => STDERR];
+    $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
     $oldOutput = getenv('CV_OUTPUT');
-    putenv("CV_OUTPUT=json");
+    putenv('CV_OUTPUT=json');
 
     // Execute `cv` in the original folder. This is a work-around for
     // phpunit/codeception, which seem to manipulate PWD.
@@ -51,8 +53,8 @@ function cv($cmd, $decode = 'json')
 
         case 'phpcode':
             // If the last output is /*PHPCODE*/, then we managed to complete execution.
-            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-                throw new \RuntimeException("Command failed ($cmd):\n$result");
+            if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+                throw new RuntimeException("Command failed ($cmd):\n$result");
             }
 
             return $result;


### PR DESCRIPTION
- all test inherit single `HeadlessTestCase`
- remove `tearDown`
- rename `*HeadlessTest` to `*Test`
- move `HeadlessTestCase` to `\Civi` namespace
- standardize `setUpHeadless()` docblock
- test class docblock: keep only `@group headless`
- remove unused `HookInterface`, `TransactionalInterface`; if needed add only relevant test cases
